### PR TITLE
Remove ready-time timeout.

### DIFF
--- a/examples/dht11.toit
+++ b/examples/dht11.toit
@@ -5,11 +5,14 @@
 import dhtxx
 import gpio
 
-GPIO-PIN-NUM ::= 14
+GPIO-PIN-NUM ::= 32
 
 main:
   pin := gpio.Pin GPIO-PIN-NUM
   driver := dhtxx.Dht11 pin
+  // On some versions of Toit/ESP-IDF it is necessary to sleep a bit before
+  // reading the sensor for the first time.
+  sleep --ms=300
 
   (Duration --s=1).periodic:
     print driver.read

--- a/examples/dht22.toit
+++ b/examples/dht22.toit
@@ -5,11 +5,14 @@
 import dhtxx
 import gpio
 
-GPIO-PIN-NUM ::= 14
+GPIO-PIN-NUM ::= 32
 
 main:
   pin := gpio.Pin GPIO-PIN-NUM
   driver := dhtxx.Dht22 pin
+  // On some versions of Toit/ESP-IDF it is necessary to sleep a bit before
+  // reading the sensor for the first time.
+  sleep --ms=300
 
   (Duration --s=1).periodic:
     print driver.read

--- a/src/dht11.toit
+++ b/src/dht11.toit
@@ -40,3 +40,6 @@ class Dht11 extends driver.Driver:
 
   parse-humidity_ data/ByteArray -> float:
     return data[HUMIDITY-INTEGRAL-PART_].to-float + data[HUMIDITY-DECIMAL-PART_] * 0.1
+
+  start-duration-us_ -> int:
+    return 18_000

--- a/src/dht22.toit
+++ b/src/dht22.toit
@@ -56,3 +56,6 @@ class Dht22 extends driver.Driver:
 
   parse-humidity_ data/ByteArray -> float:
     return (BIG-ENDIAN.uint16 data HUMIDITY-INDEX_) * 0.1
+
+  start-duration-us_ -> int:
+    return 2_000


### PR DESCRIPTION
The code had a bad comparison operator and was therefore almost never triggered.

Also make the trigger-signal shorter on the DHT22.