### PR TITLE
Update GPIO usage for SDK 2.0 alpha 196

### DIFF
--- a/examples/dht11.toit
+++ b/examples/dht11.toit
@@ -3,13 +3,11 @@
 // be found in the EXAMPLES_LICENSE file.
 
 import dhtxx
-import gpio
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  driver := dhtxx.Dht11 pin
+  driver := dhtxx.Dht11 GPIO-PIN-NUM
   // On some older versions of Toit/ESP-IDF it is necessary to sleep a bit before
   // reading the sensor for the first time.
   sleep --ms=300

--- a/examples/dht22.toit
+++ b/examples/dht22.toit
@@ -3,13 +3,11 @@
 // be found in the EXAMPLES_LICENSE file.
 
 import dhtxx
-import gpio
 
 GPIO-PIN-NUM ::= 32
 
 main:
-  pin := gpio.Pin GPIO-PIN-NUM
-  driver := dhtxx.Dht22 pin
+  driver := dhtxx.Dht22 GPIO-PIN-NUM
   // On some versions of Toit/ESP-IDF it is necessary to sleep a bit before
   // reading the sensor for the first time.
   sleep --ms=300

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ description: |
   Drivers for the DHT11 and DHT22 (aka AM2302 or RHT03) humidity and temperature sensors.
   Other compatible sensors: DHT12, KY-015, DHT33, AM2320, AM2321, or AM2322.
 environment:
-  sdk: ^2.0.0-alpha.194.1
+  sdk: ^2.0.0-alpha.196
 dependencies:
   sensors:
     url: github.com/toitware/toit-sensors

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@ description: |
   Drivers for the DHT11 and DHT22 (aka AM2302 or RHT03) humidity and temperature sensors.
   Other compatible sensors: DHT12, KY-015, DHT33, AM2320, AM2321, or AM2322.
 environment:
-  sdk: ^2.0.0-alpha.180
+  sdk: ^2.0.0-alpha.194.1
 dependencies:
   sensors:
     url: github.com/toitware/toit-sensors

--- a/src/dht11.toit
+++ b/src/dht11.toit
@@ -16,12 +16,26 @@ class Dht11 extends driver.Driver:
   static TEMPERATURE-INTEGRAL-PART_ ::= 2
   static TEMPERATURE-DECIMAL-PART_  ::= 3
 
-  /** Deprecated. Channel ids can't be used anymore and are ignored. */
-  constructor pin/gpio.Pin --in-channel-id/int --out-channel-id/int?=null --max-retries/int:
+  /**
+  Deprecated. Channel ids can't be used anymore and are ignored.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+  */
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --in-channel-id/int --out-channel-id/int?=null --max-retries/int:
     return Dht11 pin --max-retries=max-retries
 
-  /** Deprecated. Channel ids can't be used anymore and are ignored. */
-  constructor pin/gpio.Pin --out-channel-id/int --max-retries/int:
+  /**
+  Deprecated. Channel ids can't be used anymore and are ignored.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+  */
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --out-channel-id/int --max-retries/int:
     return Dht11 pin --max-retries=max-retries
 
   /**
@@ -31,8 +45,13 @@ class Dht11 extends driver.Driver:
 
   When the communication between the DHT11 and the device is flaky tries up to
     $max-retries before giving up.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
   */
-  constructor pin/gpio.Pin --max-retries/int=3:
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --max-retries/int=3:
     super pin --max-retries=max-retries
 
   parse-temperature_ data/ByteArray -> float:

--- a/src/dht22.toit
+++ b/src/dht22.toit
@@ -15,12 +15,26 @@ class Dht22 extends driver.Driver:
   static HUMIDITY-INDEX_    ::= 0
   static TEMPERATURE-INDEX_ ::= 2
 
-  /** Deprecated. Channel ids can't be used anymore and are ignored. */
-  constructor pin/gpio.Pin --in-channel-id/int --out-channel-id/int?=null --max-retries/int:
+  /**
+  Deprecated. Channel ids can't be used anymore and are ignored.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+  */
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --in-channel-id/int --out-channel-id/int?=null --max-retries/int:
     return Dht22 pin --max-retries=max-retries
 
-  /** Deprecated. Channel ids can't be used anymore and are ignored. */
-  constructor pin/gpio.Pin --out-channel-id/int --max-retries/int:
+  /**
+  Deprecated. Channel ids can't be used anymore and are ignored.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+  */
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --out-channel-id/int --max-retries/int:
     return Dht22 pin --max-retries=max-retries
 
   /**
@@ -30,8 +44,13 @@ class Dht22 extends driver.Driver:
 
   When the communication between the DHT22 and the device is flaky tries up to
     $max-retries before giving up.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
   */
-  constructor pin/gpio.Pin --max-retries/int=3:
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --max-retries/int=3:
     super pin --max-retries=max-retries
 
   parse-temperature_ data/ByteArray -> float:

--- a/src/driver_.toit
+++ b/src/driver_.toit
@@ -26,8 +26,7 @@ class DhtResult:
     return "T: $(%.2f temperature), H: $(%.2f humidity)"
 
 abstract class Driver:
-  channel-in_    /rmt.In? := ?
-  channel-out_   /rmt.Out? := ?
+  channels_      /rmt.ChannelInOut? := ?
   max-retries_   /int
   is-first-read_ /bool := true
 
@@ -37,24 +36,28 @@ abstract class Driver:
   last-read-time-us_ /int := 0
   last-result_ /ByteArray? := null
 
-  constructor pin/gpio.Pin --max-retries/int:
+  /**
+  Constructs a driver for a DHTxx sensor connected to the given $pin.
+
+  The $pin is a GPIO number. Passing a $gpio.Pin is deprecated; provide the integer
+    GPIO number instead.
+  */
+  // __TYPE-MIGRATION__ pin: gpio.Pin. Deprecated. Provide an integer instead.
+  // __TYPE-MIGRATION__ pin: int
+  constructor pin/any --max-retries/int:
     max-retries_ = max-retries
 
-    channel-in_ = rmt.In pin --resolution=1_000_000
-    channel-out_ = rmt.Out pin --resolution=1_000_000 --open-drain
+    channels_ = rmt.ChannelInOut pin --resolution=1_000_000 --open-drain
 
     high-signal := rmt.Signals 1
     high-signal.set 0 --level=1 --period=20
     // Set the line to 1.
-    channel-out_.write high-signal --done-level=1
+    channels_.out.write high-signal --done-level=1
 
   close -> none:
-    if channel-in_:
-      channel-in_.close
-      channel-in_ = null
-    if channel-out_:
-      channel-out_.close
-      channel-out_ = null
+    if channels_:
+      channels_.close
+      channels_ = null
 
   /**
   Reads the humidity and temperature.
@@ -121,8 +124,8 @@ abstract class Driver:
             last-read-time-us_ = Time.monotonic-us
             return last-result_
           finally:
-            if channel-in_.is-reading:
-              channel-in_.reset
+            if channels_.in.is-reading:
+              channels_.in.reset
     unreachable
 
   /**
@@ -141,9 +144,9 @@ abstract class Driver:
     start-signal.set 0 --level=0 --period=start-us
     // The trigger signal is, by far, the longest signal we intend to capture.
     max-ns := (start-us + 2) * 1_000
-    channel-in_.start-reading --min-ns=1_000 --max-ns=max-ns
-    channel-out_.write start-signal --done-level=1
-    response := channel-in_.wait-for-data
+    channels_.in.start-reading --min-ns=1_000 --max-ns=max-ns
+    channels_.out.write start-signal --done-level=1
+    response := channels_.in.wait-for-data
 
     // We expect to see:
     // - the start signal (low. 18ms for DHT11, 1ms for DHT22)

--- a/src/provider.toit
+++ b/src/provider.toit
@@ -2,7 +2,6 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file.
 
-import gpio
 import sensors.providers
 
 import .driver_ as dhtxx
@@ -17,16 +16,13 @@ class TemperatureSensor
     implements
       providers.TemperatureSensor-v1
       providers.HumiditySensor-v1:
-  pin_/gpio.Pin? := ?
   sensor_/dhtxx.Driver? := ?
 
   constructor.dht11 pin/int:
-    pin_ = gpio.Pin pin
-    sensor_ = dht11.Dht11 pin_
+    sensor_ = dht11.Dht11 pin
 
   constructor.dht22 pin/int:
-    pin_ = gpio.Pin pin
-    sensor_ = dht22.Dht22 pin_
+    sensor_ = dht22.Dht22 pin
 
   temperature-read -> float?:
     return sensor_.read-temperature
@@ -38,9 +34,6 @@ class TemperatureSensor
     if sensor_:
       sensor_.close
       sensor_ = null
-    if pin_:
-      pin_.close
-      pin_ = null
 
 install-dht11 pin/int -> providers.Provider:
   return install pin --variant="11"


### PR DESCRIPTION
Updates the package for the SDK 2.0.0-alpha.196 peripheral API by passing integer GPIO numbers to peripheral constructors and raising the SDK constraint. It also brings the package publishing workflow up to date where needed.